### PR TITLE
remove debugging console log

### DIFF
--- a/editMap.js
+++ b/editMap.js
@@ -1259,7 +1259,7 @@ class EditMap {
       i.wfstLayers.forEach(function (j) {
         
         if (j.options.type != "external/geojson") {
-          console.log(j);
+          //console.log(j);
           if (that.layerEditable(j.editWmsLayer.options.layers)) {
             let displayName = j.displayName;
             if (!displayName) displayName = j.name;


### PR DESCRIPTION
I am using geojson for the omr overlapping projects and this unnecessarily prints it all to the console.